### PR TITLE
Add CI/CD pipeline with luacheck and busted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: "5.1"
+
+      - uses: leafo/gh-actions-luarocks@v4
+
+      - name: Install dependencies
+        run: |
+          luarocks install luacheck
+          luarocks install busted
+
+      - name: Lint
+        run: luacheck SimpleEPGP/ --config .luacheckrc
+
+      - name: Test
+        run: busted test/


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` that runs on push and PR to master
- Lints all addon source with `luacheck SimpleEPGP/ --config .luacheckrc`
- Runs unit tests with `busted test/`
- Uses `leafo/gh-actions-lua` (Lua 5.1) and `leafo/gh-actions-luarocks` for environment setup

## Verification
Both commands pass locally:
- luacheck: 0 warnings / 0 errors in 15 files
- busted: 210 successes / 0 failures

Fixes #16

## Test plan
- [ ] Verify CI workflow runs on the PR itself
- [ ] Confirm luacheck and busted steps both pass green