### PR TITLE
Fix debug loot command to use real item data (#17)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -45,7 +45,7 @@ read_globals = {
     "GetAddOnMetadata",
 
     -- WoW Namespaced APIs
-    "C_ChatInfo", "C_GuildInfo", "C_PartyInfo", "C_Timer", "C_AddOns",
+    "C_ChatInfo", "C_GuildInfo", "C_Item", "C_PartyInfo", "C_Timer", "C_AddOns",
 
     -- WoW Constants and Tables
     "RAID_CLASS_COLORS", "ITEM_QUALITY_COLORS", "LE_ITEM_CLASS_WEAPON",


### PR DESCRIPTION
## Summary
- **Debug:CmdLoot** now fetches real item data from the server instead of constructing a fake `[Test Item 29759]` link that GPCalc can't resolve
- For cached items, the session starts immediately with the real item link
- For uncached items, registers `GET_ITEM_INFO_RECEIVED` event and calls `C_Item.RequestLoadItemDataByID()`, with a 5-second timeout for non-existent items
- Added `AceEvent-3.0` mixin to the Debug module (`SimpleEPGP:NewModule("Debug", "AceEvent-3.0")`) to enable event registration

## Changes
- `SimpleEPGP/Debug.lua`: Rewrote `CmdLoot` with cached/uncached paths, added `OnItemInfoReceived` handler and `StartLootSession` helper
- `.luacheckrc`: Added `C_Item` to `read_globals`
- `test/test_debug.lua`: Added 7 new tests covering cached item, uncached async flow, timeout, event filtering, failure handling, and race condition safety

## Test plan
- [x] `luacheck SimpleEPGP/ --config .luacheckrc` passes (0 warnings, 0 errors)
- [x] `busted test/` passes (225 successes, 0 failures)
- [ ] In-game: `/sepgp debug loot 29759` (cached T4 helm) shows real item link and correct GP
- [ ] In-game: `/sepgp debug loot 32837` (Warglaive, likely uncached) triggers server request then shows real item
- [ ] In-game: `/sepgp debug loot 99999999` (non-existent) times out with error message after 5s

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)