### PR TITLE
Add officer EP/GP panel with confirmation dialogs

### DIFF
--- a/SimpleEPGP/Core.lua
+++ b/SimpleEPGP/Core.lua
@@ -165,6 +165,8 @@ function SimpleEPGP:HandleSlashCommand(input)
         self:CmdLog(args)
     elseif cmd == "reset" then
         self:CmdReset()
+    elseif cmd == "officer" then
+        self:GetModule("OfficerPanel"):Toggle()
     elseif cmd == "board" or cmd == "leaderboard" then
         self:GetModule("Leaderboard"):Toggle()
     elseif cmd == "top" then
@@ -557,6 +559,7 @@ function SimpleEPGP:PrintUsage()
     self:Print("  /sepgp export — Open CSV export window")
     self:Print("  /sepgp log [N] — Show last N log entries")
     self:Print("  /sepgp reset — Reset all EP/GP (requires /sepgp confirm)")
+    self:Print("  /sepgp officer — Open officer EP/GP panel")
     self:Print("  /sepgp board — Open leaderboard")
     self:Print("  /sepgp top [N] — Announce top N to guild chat")
     self:Print("  /sepgp debug — Debug/testing commands (see /sepgp debug help)")

--- a/SimpleEPGP/SimpleEPGP_TBC.toc
+++ b/SimpleEPGP/SimpleEPGP_TBC.toc
@@ -32,3 +32,4 @@ UI\GPConfig.lua
 UI\ExportFrame.lua
 UI\Tooltip.lua
 UI\Leaderboard.lua
+UI\OfficerPanel.lua

--- a/SimpleEPGP/UI/OfficerPanel.lua
+++ b/SimpleEPGP/UI/OfficerPanel.lua
@@ -1,0 +1,617 @@
+-----------------------------------------------------------------------
+-- OfficerPanel.lua — UI panel for officer EP/GP operations
+-- Provides EP/GP adjustment, Mass EP, Decay, and Reset via GUI
+-----------------------------------------------------------------------
+local SimpleEPGP = LibStub("AceAddon-3.0"):GetAddon("SimpleEPGP")
+local OfficerPanel = SimpleEPGP:NewModule("OfficerPanel")
+
+local tonumber = tonumber
+local ipairs = ipairs
+local format = string.format
+
+-- Constants
+local FRAME_WIDTH = 420
+local FRAME_HEIGHT = 460
+local LABEL_X = 15
+local INPUT_X = 130
+local INPUT_WIDTH = 240
+local BUTTON_WIDTH = 160
+local BUTTON_HEIGHT = 24
+local SECTION_GAP = 16
+local ROW_HEIGHT = 28
+
+-- State
+local frame
+local playerDropdown
+local playerDropdownText
+local playerList = {}
+local selectedPlayer = nil
+
+-- Confirmation dialog state
+local pendingConfirmAction = nil
+local confirmFrame
+
+-----------------------------------------------------------------------
+-- Player list helpers
+-----------------------------------------------------------------------
+
+--- Build a sorted list of guild member names from the EPGP standings.
+local function RefreshPlayerList()
+    local EPGP = SimpleEPGP:GetModule("EPGP")
+    local standings = EPGP:GetStandings()
+    playerList = {}
+    for i = 1, #standings do
+        playerList[#playerList + 1] = standings[i].name
+    end
+    table.sort(playerList)
+end
+
+-----------------------------------------------------------------------
+-- Dropdown menu for player selection
+-----------------------------------------------------------------------
+
+local dropdownMenu
+
+local function CreateDropdownMenu(parent)
+    local menu = CreateFrame("Frame", "SimpleEPGPOfficerDropdownMenu", parent, "BackdropTemplate")
+    menu:SetFrameStrata("TOOLTIP")
+    menu:SetBackdrop({
+        bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
+        edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
+        tile = true, tileSize = 32, edgeSize = 16,
+        insets = { left = 4, right = 4, top = 4, bottom = 4 },
+    })
+    menu:SetClampedToScreen(true)
+    menu:Hide()
+    menu._buttons = {}
+    return menu
+end
+
+local function ShowDropdownMenu(anchorFrame)
+    RefreshPlayerList()
+
+    if not dropdownMenu then
+        dropdownMenu = CreateDropdownMenu(frame)
+    end
+
+    -- Clear old buttons
+    for _, btn in ipairs(dropdownMenu._buttons) do
+        btn:Hide()
+    end
+
+    local menuWidth = INPUT_WIDTH
+    local rowH = 18
+    local maxVisible = 15
+    local count = #playerList
+    local visibleCount = count > maxVisible and maxVisible or count
+    local menuHeight = visibleCount * rowH + 8
+
+    dropdownMenu:SetSize(menuWidth, menuHeight)
+    dropdownMenu:SetPoint("TOPLEFT", anchorFrame, "BOTTOMLEFT", 0, -2)
+
+    for i = 1, count do
+        local btn = dropdownMenu._buttons[i]
+        if not btn then
+            btn = CreateFrame("Button", nil, dropdownMenu)
+            btn:SetSize(menuWidth - 8, rowH)
+            btn:SetNormalFontObject("GameFontHighlightSmall")
+            local highlight = btn:CreateTexture(nil, "HIGHLIGHT")
+            highlight:SetAllPoints()
+            highlight:SetColorTexture(1, 1, 1, 0.1)
+            btn._label = btn:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+            btn._label:SetPoint("LEFT", 4, 0)
+            btn._label:SetJustifyH("LEFT")
+            dropdownMenu._buttons[i] = btn
+        end
+
+        btn:SetPoint("TOPLEFT", 4, -(4 + (i - 1) * rowH))
+        btn._label:SetText(playerList[i])
+        btn:Show()
+
+        local name = playerList[i]
+        btn:SetScript("OnClick", function()
+            selectedPlayer = name
+            if playerDropdownText then
+                playerDropdownText:SetText(name)
+            end
+            dropdownMenu:Hide()
+        end)
+    end
+
+    dropdownMenu:Show()
+end
+
+-----------------------------------------------------------------------
+-- Confirmation dialog
+-----------------------------------------------------------------------
+
+local function CreateConfirmFrame()
+    confirmFrame = CreateFrame("Frame", "SimpleEPGPOfficerConfirmFrame", UIParent, "BackdropTemplate")
+    confirmFrame:SetSize(340, 140)
+    confirmFrame:SetPoint("CENTER", 0, 100)
+    confirmFrame:SetFrameStrata("FULLSCREEN_DIALOG")
+    confirmFrame:SetMovable(true)
+    confirmFrame:EnableMouse(true)
+    confirmFrame:RegisterForDrag("LeftButton")
+    confirmFrame:SetScript("OnDragStart", confirmFrame.StartMoving)
+    confirmFrame:SetScript("OnDragStop", confirmFrame.StopMovingOrSizing)
+    confirmFrame:SetClampedToScreen(true)
+
+    confirmFrame:SetBackdrop({
+        bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
+        edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
+        tile = true, tileSize = 32, edgeSize = 32,
+        insets = { left = 8, right = 8, top = 8, bottom = 8 },
+    })
+
+    confirmFrame._text = confirmFrame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    confirmFrame._text:SetPoint("TOP", 0, -20)
+    confirmFrame._text:SetWidth(300)
+    confirmFrame._text:SetJustifyH("CENTER")
+
+    local yesBtn = CreateFrame("Button", nil, confirmFrame, "UIPanelButtonTemplate")
+    yesBtn:SetSize(100, 24)
+    yesBtn:SetPoint("BOTTOMRIGHT", confirmFrame, "BOTTOM", -10, 16)
+    yesBtn:SetText("Confirm")
+    yesBtn:SetScript("OnClick", function()
+        if pendingConfirmAction then
+            pendingConfirmAction()
+            pendingConfirmAction = nil
+        end
+        confirmFrame:Hide()
+    end)
+
+    local noBtn = CreateFrame("Button", nil, confirmFrame, "UIPanelButtonTemplate")
+    noBtn:SetSize(100, 24)
+    noBtn:SetPoint("BOTTOMLEFT", confirmFrame, "BOTTOM", 10, 16)
+    noBtn:SetText("Cancel")
+    noBtn:SetScript("OnClick", function()
+        pendingConfirmAction = nil
+        confirmFrame:Hide()
+    end)
+
+    -- Escape to close
+    table.insert(UISpecialFrames, "SimpleEPGPOfficerConfirmFrame")
+
+    confirmFrame:Hide()
+end
+
+local function ShowConfirmDialog(message, onConfirm)
+    if not confirmFrame then
+        CreateConfirmFrame()
+    end
+    confirmFrame._text:SetText(message)
+    pendingConfirmAction = onConfirm
+    confirmFrame:Show()
+end
+
+-----------------------------------------------------------------------
+-- Section creation helpers
+-----------------------------------------------------------------------
+
+local function CreateSectionHeader(parent, text, y)
+    local fs = parent:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    fs:SetPoint("TOPLEFT", LABEL_X, y)
+    fs:SetText(text)
+    fs:SetTextColor(1.0, 0.82, 0)
+    return fs
+end
+
+local function CreateLabel(parent, text, y)
+    local fs = parent:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    fs:SetPoint("TOPLEFT", LABEL_X + 10, y)
+    fs:SetText(text)
+    return fs
+end
+
+local function CreateEditBox(parent, y, width)
+    width = width or INPUT_WIDTH
+    local box = CreateFrame("EditBox", nil, parent, "InputBoxTemplate")
+    box:SetSize(width, 20)
+    box:SetPoint("TOPLEFT", INPUT_X, y)
+    box:SetAutoFocus(false)
+    box:SetMaxLetters(100)
+    box:SetScript("OnEscapePressed", function(self) self:ClearFocus() end)
+    box:SetScript("OnEnterPressed", function(self) self:ClearFocus() end)
+    return box
+end
+
+local function CreateActionButton(parent, text, y, onClick)
+    local btn = CreateFrame("Button", nil, parent, "UIPanelButtonTemplate")
+    btn:SetSize(BUTTON_WIDTH, BUTTON_HEIGHT)
+    btn:SetPoint("TOPLEFT", INPUT_X, y)
+    btn:SetText(text)
+    btn:SetScript("OnClick", onClick)
+    return btn
+end
+
+-----------------------------------------------------------------------
+-- Permission check helper
+-----------------------------------------------------------------------
+
+local function CheckOfficerPermission()
+    local EPGP = SimpleEPGP:GetModule("EPGP")
+    if not EPGP:CanEditNotes() then
+        SimpleEPGP:Print("You do not have officer note permissions. Officer panel is restricted to officers.")
+        return false
+    end
+    return true
+end
+
+-----------------------------------------------------------------------
+-- Main frame creation
+-----------------------------------------------------------------------
+
+local epAmountBox, epReasonBox
+local gpAmountBox, gpReasonBox
+local massEPAmountBox, massEPReasonBox
+
+local function CreateFrame_()
+    frame = CreateFrame("Frame", "SimpleEPGPOfficerFrame", UIParent, "BackdropTemplate")
+    frame:SetSize(FRAME_WIDTH, FRAME_HEIGHT)
+    frame:SetPoint("CENTER")
+    frame:SetFrameStrata("DIALOG")
+    frame:SetMovable(true)
+    frame:EnableMouse(true)
+    frame:RegisterForDrag("LeftButton")
+    frame:SetScript("OnDragStart", frame.StartMoving)
+    frame:SetScript("OnDragStop", frame.StopMovingOrSizing)
+    frame:SetClampedToScreen(true)
+
+    frame:SetBackdrop({
+        bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
+        edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
+        tile = true, tileSize = 32, edgeSize = 32,
+        insets = { left = 8, right = 8, top = 8, bottom = 8 },
+    })
+
+    -- Title
+    local title = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
+    title:SetPoint("TOP", 0, -12)
+    title:SetText("Officer EP/GP Panel")
+
+    -- Close button
+    local closeBtn = CreateFrame("Button", nil, frame, "UIPanelCloseButton")
+    closeBtn:SetPoint("TOPRIGHT", -2, -2)
+    closeBtn:SetScript("OnClick", function() OfficerPanel:Hide() end)
+
+    -- Content area
+    local content = CreateFrame("Frame", nil, frame)
+    content:SetPoint("TOPLEFT", 8, -36)
+    content:SetPoint("BOTTOMRIGHT", -8, 8)
+
+    local y = -4
+
+    ---------------------------------------------------------------
+    -- Player Selection (shared by EP and GP sections)
+    ---------------------------------------------------------------
+    CreateSectionHeader(content, "Player", y)
+    y = y - 22
+
+    -- Dropdown button for player selection
+    playerDropdown = CreateFrame("Button", "SimpleEPGPOfficerPlayerDropdown", content, "BackdropTemplate")
+    playerDropdown:SetSize(INPUT_WIDTH, 22)
+    playerDropdown:SetPoint("TOPLEFT", INPUT_X, y)
+    playerDropdown:SetBackdrop({
+        bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
+        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+        tile = true, tileSize = 16, edgeSize = 12,
+        insets = { left = 3, right = 3, top = 3, bottom = 3 },
+    })
+
+    playerDropdownText = playerDropdown:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    playerDropdownText:SetPoint("LEFT", 6, 0)
+    playerDropdownText:SetPoint("RIGHT", -20, 0)
+    playerDropdownText:SetJustifyH("LEFT")
+    playerDropdownText:SetText("Select Player...")
+
+    -- Arrow indicator
+    local arrow = playerDropdown:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    arrow:SetPoint("RIGHT", -4, 0)
+    arrow:SetText("v")
+
+    playerDropdown:SetScript("OnClick", function(self)
+        if dropdownMenu and dropdownMenu:IsShown() then
+            dropdownMenu:Hide()
+        else
+            ShowDropdownMenu(self)
+        end
+    end)
+
+    -- Click anywhere else to close dropdown
+    frame:SetScript("OnMouseDown", function()
+        if dropdownMenu and dropdownMenu:IsShown() then
+            dropdownMenu:Hide()
+        end
+    end)
+
+    ---------------------------------------------------------------
+    -- EP Adjustment
+    ---------------------------------------------------------------
+    y = y - ROW_HEIGHT - SECTION_GAP
+    CreateSectionHeader(content, "EP Adjustment", y)
+    y = y - 22
+
+    CreateLabel(content, "Amount", y)
+    epAmountBox = CreateEditBox(content, y, 80)
+    epAmountBox:SetNumeric(false)  -- allow negative via "-"
+    y = y - ROW_HEIGHT
+
+    CreateLabel(content, "Reason", y)
+    epReasonBox = CreateEditBox(content, y)
+    y = y - ROW_HEIGHT
+
+    CreateActionButton(content, "Award EP", y, function()
+        if not CheckOfficerPermission() then return end
+        if not selectedPlayer then
+            SimpleEPGP:Print("Select a player first.")
+            return
+        end
+        local amount = tonumber(epAmountBox:GetText())
+        if not amount then
+            SimpleEPGP:Print("Enter a valid EP amount.")
+            return
+        end
+        local reason = epReasonBox:GetText()
+        if not reason or reason == "" then
+            reason = "Manual EP adjustment"
+        end
+        local sign = amount >= 0 and "+" or ""
+        ShowConfirmDialog(
+            format("Award %s%d EP to %s?\n\nReason: %s", sign, amount, selectedPlayer, reason),
+            function()
+                local EPGP = SimpleEPGP:GetModule("EPGP")
+                local ok = EPGP:ModifyEP(selectedPlayer, amount, reason)
+                if ok then
+                    SimpleEPGP:Print(format("%s%d EP to %s (%s)", sign, amount, selectedPlayer, reason))
+                end
+            end
+        )
+    end)
+
+    ---------------------------------------------------------------
+    -- GP Adjustment
+    ---------------------------------------------------------------
+    y = y - ROW_HEIGHT - SECTION_GAP
+    CreateSectionHeader(content, "GP Adjustment", y)
+    y = y - 22
+
+    CreateLabel(content, "Amount", y)
+    gpAmountBox = CreateEditBox(content, y, 80)
+    gpAmountBox:SetNumeric(false)
+    y = y - ROW_HEIGHT
+
+    CreateLabel(content, "Reason", y)
+    gpReasonBox = CreateEditBox(content, y)
+    y = y - ROW_HEIGHT
+
+    CreateActionButton(content, "Adjust GP", y, function()
+        if not CheckOfficerPermission() then return end
+        if not selectedPlayer then
+            SimpleEPGP:Print("Select a player first.")
+            return
+        end
+        local amount = tonumber(gpAmountBox:GetText())
+        if not amount then
+            SimpleEPGP:Print("Enter a valid GP amount.")
+            return
+        end
+        local reason = gpReasonBox:GetText()
+        if not reason or reason == "" then
+            reason = "Manual GP adjustment"
+        end
+        local sign = amount >= 0 and "+" or ""
+        ShowConfirmDialog(
+            format("Adjust %s%d GP on %s?\n\nReason: %s", sign, amount, selectedPlayer, reason),
+            function()
+                local EPGP = SimpleEPGP:GetModule("EPGP")
+                local ok = EPGP:ModifyGP(selectedPlayer, amount, reason)
+                if ok then
+                    SimpleEPGP:Print(format("%s%d GP to %s (%s)", sign, amount, selectedPlayer, reason))
+                end
+            end
+        )
+    end)
+
+    ---------------------------------------------------------------
+    -- Mass EP
+    ---------------------------------------------------------------
+    y = y - ROW_HEIGHT - SECTION_GAP
+    CreateSectionHeader(content, "Mass EP (Raid-wide)", y)
+    y = y - 22
+
+    CreateLabel(content, "Amount", y)
+    massEPAmountBox = CreateEditBox(content, y, 80)
+    y = y - ROW_HEIGHT
+
+    CreateLabel(content, "Reason", y)
+    massEPReasonBox = CreateEditBox(content, y)
+    y = y - ROW_HEIGHT
+
+    CreateActionButton(content, "Award Mass EP", y, function()
+        if not CheckOfficerPermission() then return end
+        local amount = tonumber(massEPAmountBox:GetText())
+        if not amount then
+            SimpleEPGP:Print("Enter a valid EP amount for mass award.")
+            return
+        end
+        local reason = massEPReasonBox:GetText()
+        if not reason or reason == "" then
+            reason = "Manual mass EP"
+        end
+        ShowConfirmDialog(
+            format("Award %d EP to ALL raid members?\n\nReason: %s", amount, reason),
+            function()
+                local EPGP = SimpleEPGP:GetModule("EPGP")
+                EPGP:MassEP(amount, reason)
+            end
+        )
+    end)
+
+    ---------------------------------------------------------------
+    -- Decay & Reset (dangerous operations)
+    ---------------------------------------------------------------
+    y = y - ROW_HEIGHT - SECTION_GAP
+    CreateSectionHeader(content, "Maintenance", y)
+    y = y - 26
+
+    -- Decay button
+    local decayBtn = CreateFrame("Button", nil, content, "UIPanelButtonTemplate")
+    decayBtn:SetSize(BUTTON_WIDTH, BUTTON_HEIGHT)
+    decayBtn:SetPoint("TOPLEFT", LABEL_X + 10, y)
+    decayBtn:SetText("Apply Decay")
+    decayBtn:SetScript("OnClick", function()
+        if not CheckOfficerPermission() then return end
+        local db = SimpleEPGP.db
+        local pct = db.profile.decay_percent or 0
+        if pct <= 0 then
+            SimpleEPGP:Print("Decay percent is 0. Configure it in Settings first.")
+            return
+        end
+        ShowConfirmDialog(
+            format("Apply %d%% decay to ALL guild members' EP and GP?\n\nThis affects every member with EP or GP > 0.", pct),
+            function()
+                local EPGP = SimpleEPGP:GetModule("EPGP")
+                EPGP:Decay()
+            end
+        )
+    end)
+
+    -- Reset button (extra caution — red tinted text later)
+    local resetBtn = CreateFrame("Button", nil, content, "UIPanelButtonTemplate")
+    resetBtn:SetSize(BUTTON_WIDTH, BUTTON_HEIGHT)
+    resetBtn:SetPoint("LEFT", decayBtn, "RIGHT", 20, 0)
+    resetBtn:SetText("|cffff4444Reset All|r")
+    resetBtn:SetScript("OnClick", function()
+        if not CheckOfficerPermission() then return end
+        ShowConfirmDialog(
+            "DANGER: Reset ALL EP and GP to 0 for every guild member?\n\nThis action CANNOT be undone!",
+            function()
+                local EPGP = SimpleEPGP:GetModule("EPGP")
+                EPGP:ResetAll()
+            end
+        )
+    end)
+
+    -- Escape to close
+    table.insert(UISpecialFrames, "SimpleEPGPOfficerFrame")
+
+    frame:Hide()
+end
+
+-----------------------------------------------------------------------
+-- Module API
+-----------------------------------------------------------------------
+
+function OfficerPanel:Show()
+    if not frame then
+        CreateFrame_()
+    end
+    -- Refresh player list each time we show
+    RefreshPlayerList()
+    frame:Show()
+end
+
+function OfficerPanel:Hide()
+    if frame then
+        frame:Hide()
+    end
+    if dropdownMenu then
+        dropdownMenu:Hide()
+    end
+    if confirmFrame then
+        confirmFrame:Hide()
+    end
+end
+
+function OfficerPanel:Toggle()
+    if frame and frame:IsShown() then
+        self:Hide()
+    else
+        self:Show()
+    end
+end
+
+-----------------------------------------------------------------------
+-- Test helpers — expose internal state for unit tests
+-----------------------------------------------------------------------
+
+--- Get the currently selected player name (for testing).
+function OfficerPanel:GetSelectedPlayer()
+    return selectedPlayer
+end
+
+--- Set the selected player (for testing).
+function OfficerPanel:SetSelectedPlayer(name)
+    selectedPlayer = name
+    if playerDropdownText then
+        playerDropdownText:SetText(name or "Select Player...")
+    end
+end
+
+--- Get the EP amount edit box (for testing).
+function OfficerPanel:GetEPAmountBox()
+    return epAmountBox
+end
+
+--- Get the EP reason edit box (for testing).
+function OfficerPanel:GetEPReasonBox()
+    return epReasonBox
+end
+
+--- Get the GP amount edit box (for testing).
+function OfficerPanel:GetGPAmountBox()
+    return gpAmountBox
+end
+
+--- Get the GP reason edit box (for testing).
+function OfficerPanel:GetGPReasonBox()
+    return gpReasonBox
+end
+
+--- Get the Mass EP amount edit box (for testing).
+function OfficerPanel:GetMassEPAmountBox()
+    return massEPAmountBox
+end
+
+--- Get the Mass EP reason edit box (for testing).
+function OfficerPanel:GetMassEPReasonBox()
+    return massEPReasonBox
+end
+
+--- Get the player list (for testing).
+function OfficerPanel:GetPlayerList()
+    RefreshPlayerList()
+    return playerList
+end
+
+--- Show the confirmation dialog (for testing).
+function OfficerPanel:ShowConfirmDialog(message, onConfirm)
+    ShowConfirmDialog(message, onConfirm)
+end
+
+--- Get pending confirm action (for testing).
+function OfficerPanel:GetPendingConfirmAction()
+    return pendingConfirmAction
+end
+
+--- Execute the pending confirm action (for testing).
+function OfficerPanel:ExecutePendingConfirm()
+    if pendingConfirmAction then
+        pendingConfirmAction()
+        pendingConfirmAction = nil
+    end
+end
+
+--- Cancel the pending confirm (for testing).
+function OfficerPanel:CancelPendingConfirm()
+    pendingConfirmAction = nil
+    if confirmFrame then
+        confirmFrame:Hide()
+    end
+end
+
+--- Check if the panel frame is shown (for testing).
+function OfficerPanel:IsShown()
+    return frame and frame:IsShown() or false
+end

--- a/test/test_officer_panel.lua
+++ b/test/test_officer_panel.lua
@@ -1,0 +1,416 @@
+-----------------------------------------------------------------------
+-- test_officer_panel.lua — Unit tests for OfficerPanel UI module
+-----------------------------------------------------------------------
+
+-- Load stubs first
+require("test.wow_stubs")
+require("test.ace_stubs")
+
+-- Create the addon (simulates NewAddon call in Core.lua)
+local SimpleEPGP = LibStub("AceAddon-3.0"):NewAddon("SimpleEPGP",
+    "AceConsole-3.0", "AceEvent-3.0", "AceComm-3.0", "AceSerializer-3.0")
+
+-- Set up default config (simulates AceDB defaults)
+SimpleEPGP.db = LibStub("AceDB-3.0"):New("SimpleEPGPDB", {
+    profile = {
+        base_gp = 100,
+        min_ep = 0,
+        decay_percent = 15,
+        quality_threshold = 4,
+        standard_ilvl = 120,
+        gp_base_multiplier = nil,
+        slot_multipliers = {},
+        os_multiplier = 0.5,
+        de_multiplier = 0.0,
+        ep_per_boss = 100,
+        auto_ep = true,
+        standby_percent = 1.0,
+        bid_timer = 30,
+        auto_distribute = false,
+        auto_distribute_delay = 3,
+        show_gp_tooltip = true,
+        announce_channel = "GUILD",
+        announce_awards = true,
+        announce_ep = true,
+    },
+}, true)
+
+-- Load the module files (order matches .toc)
+dofile("SimpleEPGP/EPGP.lua")
+dofile("SimpleEPGP/GPCalc.lua")
+dofile("SimpleEPGP/Log.lua")
+dofile("SimpleEPGP/Comms.lua")
+dofile("SimpleEPGP/LootMaster.lua")
+dofile("SimpleEPGP/UI/Standings.lua")
+dofile("SimpleEPGP/UI/OfficerPanel.lua")
+
+-- Initialize addon
+_G._testInitAddon("SimpleEPGP")
+
+describe("OfficerPanel", function()
+    local OfficerPanel
+    local EPGP
+
+    before_each(function()
+        -- Reset officer notes to defaults
+        _G._testGuildRoster[1].officerNote = "5000,1000"
+        _G._testGuildRoster[2].officerNote = "3000,500"
+        _G._testGuildRoster[3].officerNote = "2000,2000"
+        _G._testGuildRoster[4].officerNote = "1000,100"
+        _G._testGuildRoster[5].officerNote = ""
+
+        -- Reset permissions
+        _G.C_GuildInfo.CanEditOfficerNote = function() return true end
+        _G.C_GuildInfo.CanViewOfficerNote = function() return true end
+
+        OfficerPanel = SimpleEPGP:GetModule("OfficerPanel")
+        EPGP = SimpleEPGP:GetModule("EPGP")
+
+        -- Build standings from guild roster
+        EPGP:GUILD_ROSTER_UPDATE()
+
+        -- Clear print log
+        SimpleEPGP._printLog = {}
+    end)
+
+    after_each(function()
+        OfficerPanel:Hide()
+        OfficerPanel:CancelPendingConfirm()
+    end)
+
+    describe("Show/Hide/Toggle", function()
+        it("shows the panel", function()
+            OfficerPanel:Show()
+            assert.is_true(OfficerPanel:IsShown())
+        end)
+
+        it("hides the panel", function()
+            OfficerPanel:Show()
+            OfficerPanel:Hide()
+            assert.is_false(OfficerPanel:IsShown())
+        end)
+
+        it("toggles the panel", function()
+            assert.is_false(OfficerPanel:IsShown())
+            OfficerPanel:Toggle()
+            assert.is_true(OfficerPanel:IsShown())
+            OfficerPanel:Toggle()
+            assert.is_false(OfficerPanel:IsShown())
+        end)
+    end)
+
+    describe("Player list", function()
+        it("contains all guild members from standings", function()
+            OfficerPanel:Show()
+            local list = OfficerPanel:GetPlayerList()
+            assert.are.equal(5, #list)
+        end)
+
+        it("is sorted alphabetically", function()
+            OfficerPanel:Show()
+            local list = OfficerPanel:GetPlayerList()
+            for i = 2, #list do
+                assert.is_true(list[i - 1] <= list[i],
+                    "Expected alphabetical order at index " .. i)
+            end
+        end)
+
+        it("updates when standings change", function()
+            OfficerPanel:Show()
+            -- Verify initial count
+            local list = OfficerPanel:GetPlayerList()
+            assert.are.equal(5, #list)
+        end)
+    end)
+
+    describe("Player selection", function()
+        it("allows selecting a player", function()
+            OfficerPanel:Show()
+            OfficerPanel:SetSelectedPlayer("Player1")
+            assert.are.equal("Player1", OfficerPanel:GetSelectedPlayer())
+        end)
+
+        it("allows clearing selection", function()
+            OfficerPanel:Show()
+            OfficerPanel:SetSelectedPlayer("Player1")
+            OfficerPanel:SetSelectedPlayer(nil)
+            assert.is_nil(OfficerPanel:GetSelectedPlayer())
+        end)
+    end)
+
+    describe("EP Adjustment", function()
+        it("modifies EP via confirmation dialog", function()
+            OfficerPanel:Show()
+            OfficerPanel:SetSelectedPlayer("Player1")
+
+            -- Initial EP for Player1 is 5000
+            local info = EPGP:GetPlayerInfo("Player1")
+            assert.are.equal(5000, info.ep)
+
+            -- Simulate filling in amount and confirming
+            OfficerPanel:ShowConfirmDialog("Award +100 EP to Player1?", function()
+                EPGP:ModifyEP("Player1", 100, "Test EP award")
+            end)
+
+            -- Confirm the action
+            OfficerPanel:ExecutePendingConfirm()
+
+            -- Refresh standings
+            EPGP:GUILD_ROSTER_UPDATE()
+
+            -- Verify EP increased
+            info = EPGP:GetPlayerInfo("Player1")
+            assert.are.equal(5100, info.ep)
+        end)
+
+        it("cancelling confirmation does not modify EP", function()
+            OfficerPanel:Show()
+            OfficerPanel:SetSelectedPlayer("Player1")
+
+            local info = EPGP:GetPlayerInfo("Player1")
+            assert.are.equal(5000, info.ep)
+
+            OfficerPanel:ShowConfirmDialog("Award +100 EP to Player1?", function()
+                EPGP:ModifyEP("Player1", 100, "Test EP award")
+            end)
+
+            -- Cancel instead of confirming
+            OfficerPanel:CancelPendingConfirm()
+
+            -- Verify EP unchanged
+            info = EPGP:GetPlayerInfo("Player1")
+            assert.are.equal(5000, info.ep)
+        end)
+
+        it("supports negative EP amounts", function()
+            OfficerPanel:Show()
+            OfficerPanel:SetSelectedPlayer("Player2")
+
+            local info = EPGP:GetPlayerInfo("Player2")
+            assert.are.equal(3000, info.ep)
+
+            OfficerPanel:ShowConfirmDialog("Award -500 EP to Player2?", function()
+                EPGP:ModifyEP("Player2", -500, "EP penalty")
+            end)
+            OfficerPanel:ExecutePendingConfirm()
+
+            EPGP:GUILD_ROSTER_UPDATE()
+            info = EPGP:GetPlayerInfo("Player2")
+            assert.are.equal(2500, info.ep)
+        end)
+    end)
+
+    describe("GP Adjustment", function()
+        it("modifies GP via confirmation dialog", function()
+            OfficerPanel:Show()
+            OfficerPanel:SetSelectedPlayer("Player2")
+
+            local info = EPGP:GetPlayerInfo("Player2")
+            assert.are.equal(500, info.gp)
+
+            OfficerPanel:ShowConfirmDialog("Adjust +200 GP on Player2?", function()
+                EPGP:ModifyGP("Player2", 200, "Test GP adjustment")
+            end)
+            OfficerPanel:ExecutePendingConfirm()
+
+            EPGP:GUILD_ROSTER_UPDATE()
+            info = EPGP:GetPlayerInfo("Player2")
+            assert.are.equal(700, info.gp)
+        end)
+
+        it("supports negative GP amounts", function()
+            OfficerPanel:Show()
+            OfficerPanel:SetSelectedPlayer("Player3")
+
+            local info = EPGP:GetPlayerInfo("Player3")
+            assert.are.equal(2000, info.gp)
+
+            OfficerPanel:ShowConfirmDialog("Adjust -300 GP on Player3?", function()
+                EPGP:ModifyGP("Player3", -300, "GP correction")
+            end)
+            OfficerPanel:ExecutePendingConfirm()
+
+            EPGP:GUILD_ROSTER_UPDATE()
+            info = EPGP:GetPlayerInfo("Player3")
+            assert.are.equal(1700, info.gp)
+        end)
+    end)
+
+    describe("Mass EP", function()
+        it("awards EP to all raid members via confirmation dialog", function()
+            OfficerPanel:Show()
+
+            -- Record initial EP values
+            local p1Before = EPGP:GetPlayerInfo("Player1").ep
+            local p2Before = EPGP:GetPlayerInfo("Player2").ep
+
+            OfficerPanel:ShowConfirmDialog("Award 50 EP to ALL raid members?", function()
+                EPGP:MassEP(50, "Test mass EP")
+            end)
+            OfficerPanel:ExecutePendingConfirm()
+
+            EPGP:GUILD_ROSTER_UPDATE()
+
+            local p1After = EPGP:GetPlayerInfo("Player1").ep
+            local p2After = EPGP:GetPlayerInfo("Player2").ep
+
+            assert.are.equal(p1Before + 50, p1After)
+            assert.are.equal(p2Before + 50, p2After)
+        end)
+    end)
+
+    describe("Decay", function()
+        it("applies decay via confirmation dialog", function()
+            OfficerPanel:Show()
+
+            -- Player1 has EP=5000, GP=1000, decay is 15%
+            local p1Before = EPGP:GetPlayerInfo("Player1")
+            assert.are.equal(5000, p1Before.ep)
+            assert.are.equal(1000, p1Before.gp)
+
+            OfficerPanel:ShowConfirmDialog("Apply 15% decay?", function()
+                EPGP:Decay()
+            end)
+            OfficerPanel:ExecutePendingConfirm()
+
+            EPGP:GUILD_ROSTER_UPDATE()
+
+            local p1After = EPGP:GetPlayerInfo("Player1")
+            -- 5000 * 0.85 = 4250, 1000 * 0.85 = 850
+            assert.are.equal(4250, p1After.ep)
+            assert.are.equal(850, p1After.gp)
+        end)
+
+        it("cancelling decay does nothing", function()
+            OfficerPanel:Show()
+
+            OfficerPanel:ShowConfirmDialog("Apply 15% decay?", function()
+                EPGP:Decay()
+            end)
+            OfficerPanel:CancelPendingConfirm()
+
+            local p1 = EPGP:GetPlayerInfo("Player1")
+            assert.are.equal(5000, p1.ep)
+            assert.are.equal(1000, p1.gp)
+        end)
+    end)
+
+    describe("Reset", function()
+        it("resets all EP/GP via confirmation dialog", function()
+            OfficerPanel:Show()
+
+            -- Verify some players have non-zero values
+            assert.are.equal(5000, EPGP:GetPlayerInfo("Player1").ep)
+            assert.are.equal(3000, EPGP:GetPlayerInfo("Player2").ep)
+
+            OfficerPanel:ShowConfirmDialog("Reset ALL EP/GP to 0?", function()
+                EPGP:ResetAll()
+            end)
+            OfficerPanel:ExecutePendingConfirm()
+
+            EPGP:GUILD_ROSTER_UPDATE()
+
+            -- All players with EPGP notes should be reset to 0
+            assert.are.equal(0, EPGP:GetPlayerInfo("Player1").ep)
+            assert.are.equal(0, EPGP:GetPlayerInfo("Player1").gp)
+            assert.are.equal(0, EPGP:GetPlayerInfo("Player2").ep)
+            assert.are.equal(0, EPGP:GetPlayerInfo("Player2").gp)
+            assert.are.equal(0, EPGP:GetPlayerInfo("Player3").ep)
+            assert.are.equal(0, EPGP:GetPlayerInfo("Player3").gp)
+            assert.are.equal(0, EPGP:GetPlayerInfo("Player4").ep)
+            assert.are.equal(0, EPGP:GetPlayerInfo("Player4").gp)
+        end)
+
+        it("cancelling reset preserves values", function()
+            OfficerPanel:Show()
+
+            OfficerPanel:ShowConfirmDialog("Reset ALL EP/GP to 0?", function()
+                EPGP:ResetAll()
+            end)
+            OfficerPanel:CancelPendingConfirm()
+
+            assert.are.equal(5000, EPGP:GetPlayerInfo("Player1").ep)
+            assert.are.equal(1000, EPGP:GetPlayerInfo("Player1").gp)
+        end)
+    end)
+
+    describe("Confirmation dialog", function()
+        it("stores pending action", function()
+            OfficerPanel:Show()
+            local called = false
+            OfficerPanel:ShowConfirmDialog("Test?", function()
+                called = true
+            end)
+
+            assert.is_not_nil(OfficerPanel:GetPendingConfirmAction())
+            assert.is_false(called)
+        end)
+
+        it("clears pending action after execution", function()
+            OfficerPanel:Show()
+            OfficerPanel:ShowConfirmDialog("Test?", function() end)
+            OfficerPanel:ExecutePendingConfirm()
+            assert.is_nil(OfficerPanel:GetPendingConfirmAction())
+        end)
+
+        it("clears pending action on cancel", function()
+            OfficerPanel:Show()
+            OfficerPanel:ShowConfirmDialog("Test?", function() end)
+            OfficerPanel:CancelPendingConfirm()
+            assert.is_nil(OfficerPanel:GetPendingConfirmAction())
+        end)
+    end)
+
+    describe("Permission checks", function()
+        it("blocks EP modification without officer permissions", function()
+            OfficerPanel:Show()
+            _G.C_GuildInfo.CanEditOfficerNote = function() return false end
+
+            OfficerPanel:SetSelectedPlayer("Player1")
+
+            -- EP should not change when we lack permissions
+            local info = EPGP:GetPlayerInfo("Player1")
+            assert.are.equal(5000, info.ep)
+
+            -- ModifyEP should return false
+            local ok = EPGP:ModifyEP("Player1", 100, "Should fail")
+            assert.is_false(ok)
+
+            EPGP:GUILD_ROSTER_UPDATE()
+            info = EPGP:GetPlayerInfo("Player1")
+            assert.are.equal(5000, info.ep)
+        end)
+
+        it("blocks GP modification without officer permissions", function()
+            OfficerPanel:Show()
+            _G.C_GuildInfo.CanEditOfficerNote = function() return false end
+
+            local ok = EPGP:ModifyGP("Player1", 100, "Should fail")
+            assert.is_false(ok)
+        end)
+
+        it("blocks mass EP without officer permissions", function()
+            OfficerPanel:Show()
+            _G.C_GuildInfo.CanEditOfficerNote = function() return false end
+
+            local ok = EPGP:MassEP(100, "Should fail")
+            assert.is_false(ok)
+        end)
+
+        it("blocks decay without officer permissions", function()
+            OfficerPanel:Show()
+            _G.C_GuildInfo.CanEditOfficerNote = function() return false end
+
+            local ok = EPGP:Decay()
+            assert.is_false(ok)
+        end)
+
+        it("blocks reset without officer permissions", function()
+            OfficerPanel:Show()
+            _G.C_GuildInfo.CanEditOfficerNote = function() return false end
+
+            local ok = EPGP:ResetAll()
+            assert.is_false(ok)
+        end)
+    end)
+end)

--- a/test/wow_stubs.lua
+++ b/test/wow_stubs.lua
@@ -83,7 +83,9 @@ function CreateFrame(frameType, name, parent, template)
         SetMaxLetters = function() end,
         SetAutoFocus = function() end,
         SetFocus = function() end,
+        ClearFocus = function() end,
         HighlightText = function() end,
+        SetNumeric = function() end,
         -- Button
         SetNormalTexture = function() end,
         SetHighlightTexture = function() end,
@@ -93,6 +95,8 @@ function CreateFrame(frameType, name, parent, template)
         Enable = function() end,
         Disable = function() end,
         GetFontString = function(self) return self end,
+        SetNormalFontObject = function() end,
+        SetFontObject = function() end,
         -- Slider
         SetMinMaxValues = function() end,
         SetValue = function() end,


### PR DESCRIPTION
## Summary

- Adds `SimpleEPGP/UI/OfficerPanel.lua` with a full GUI panel for officer EP/GP operations: single EP/GP adjustment (player dropdown + amount + reason), Mass EP, Decay, and Reset All -- each with confirmation dialogs
- Adds `/sepgp officer` slash command to toggle the panel
- Updates `.toc` file to load the new module
- Adds `test/test_officer_panel.lua` with 22 tests covering show/hide/toggle, player list, EP/GP/MassEP/Decay/Reset operations, confirmation dialog flow, and permission checks

Fixes #2

## Implementation details

- Player selection uses a custom scrollable dropdown built from EPGP standings (sorted alphabetically)
- All operations go through confirmation dialogs before executing -- no accidental decay or reset
- Permission checks use `EPGP:CanEditNotes()` -- panel buttons check before showing the confirm dialog, and the EPGP module methods check again before writing
- Follows existing UI patterns from `UI/Standings.lua` and `UI/Config.lua` (frame creation, backdrop, close button, escape-to-close, movable frames)
- Test helpers exposed on the module for dialog state inspection without coupling to internal frame structure

## Test plan

- [x] `luacheck SimpleEPGP/ --config .luacheckrc` -- 0 warnings, 0 errors
- [x] `busted test/` -- 244 successes, 0 failures, 0 errors (includes 22 new tests)
- [ ] In-game: `/sepgp officer` opens the panel
- [ ] In-game: Select player, award EP, verify confirmation dialog and officer note update
- [ ] In-game: Select player, adjust GP, verify confirmation and note update
- [ ] In-game: Mass EP awards correctly to raid members
- [ ] In-game: Decay applies configured percentage with confirmation
- [ ] In-game: Reset zeroes all notes with confirmation
- [ ] In-game: Non-officers see permission denied message