### PR TITLE
Add visual indicator for external players in UI (#13)

### DIFF
--- a/SimpleEPGP/UI/ExportFrame.lua
+++ b/SimpleEPGP/UI/ExportFrame.lua
@@ -16,9 +16,10 @@ local activeTab = "standings"
 local function BuildStandingsCSV()
     local EPGP = SimpleEPGP:GetModule("EPGP")
     local standings = EPGP:GetStandings()
-    local lines = { "Name,Class,EP,GP,PR" }
+    local lines = { "Name,Class,EP,GP,PR,Source" }
     for _, s in ipairs(standings) do
-        lines[#lines + 1] = format("%s,%s,%d,%d,%.2f", s.name, s.class, s.ep, s.gp, s.pr)
+        local source = s.isExternal and "external" or "guild"
+        lines[#lines + 1] = format("%s,%s,%d,%d,%.2f,%s", s.name, s.class, s.ep, s.gp, s.pr, source)
     end
     return tconcat(lines, "\n")
 end
@@ -190,4 +191,10 @@ function ExportFrame:Toggle()
     else
         self:Show()
     end
+end
+
+--- Get the standings CSV text (for testing).
+-- @return string CSV content with header and data rows
+function ExportFrame:GetStandingsCSV()
+    return BuildStandingsCSV()
 end

--- a/SimpleEPGP/UI/Leaderboard.lua
+++ b/SimpleEPGP/UI/Leaderboard.lua
@@ -537,14 +537,18 @@ function Leaderboard:Refresh()
                 row.rank:SetTextColor(0.8, 0.8, 0.8)
             end
 
-            -- Class-colored name
+            -- Class-colored name, with external player indicator
+            local displayName = entry.name
+            if entry.isExternal then
+                displayName = displayName .. " *"
+            end
             local classColor = RAID_CLASS_COLORS[entry.class]
             if classColor then
                 row.name:SetTextColor(classColor.r, classColor.g, classColor.b)
             else
                 row.name:SetTextColor(1, 1, 1)
             end
-            row.name:SetText(entry.name)
+            row.name:SetText(displayName)
 
             -- EP, GP, PR
             row.ep:SetText(tostring(entry.ep))
@@ -563,6 +567,10 @@ function Leaderboard:Refresh()
             else
                 row.highlight:Hide()
             end
+
+            -- Slightly reduce alpha for external players
+            local rowAlpha = entry.isExternal and 0.8 or 1.0
+            row:SetAlpha(rowAlpha)
 
             row:Show()
             yPos = yPos + ROW_HEIGHT

--- a/SimpleEPGP/UI/Standings.lua
+++ b/SimpleEPGP/UI/Standings.lua
@@ -94,12 +94,16 @@ local function UpdateRows()
             local entry = sortedData[dataIndex]
             row:Show()
 
-            -- Name colored by class
+            -- Name colored by class, with external player indicator
+            local displayName = entry.name
+            if entry.isExternal then
+                displayName = displayName .. " *"
+            end
             local classColor = RAID_CLASS_COLORS[entry.class]
             if classColor then
-                row.name:SetText("|c" .. classColor.colorStr .. entry.name .. "|r")
+                row.name:SetText("|c" .. classColor.colorStr .. displayName .. "|r")
             else
-                row.name:SetText(entry.name)
+                row.name:SetText(displayName)
             end
 
             row.class:SetText(entry.class)
@@ -107,20 +111,18 @@ local function UpdateRows()
             row.gp:SetText(tostring(entry.gp))
             row.pr:SetText(format("%.2f", entry.pr))
 
-            -- Grey out players below min EP threshold
+            -- Grey out players below min EP threshold; reduce alpha for external
+            local alpha = 1.0
             if entry.ep < minEP then
-                row.name:SetAlpha(0.5)
-                row.class:SetAlpha(0.5)
-                row.ep:SetAlpha(0.5)
-                row.gp:SetAlpha(0.5)
-                row.pr:SetAlpha(0.5)
-            else
-                row.name:SetAlpha(1.0)
-                row.class:SetAlpha(1.0)
-                row.ep:SetAlpha(1.0)
-                row.gp:SetAlpha(1.0)
-                row.pr:SetAlpha(1.0)
+                alpha = 0.5
+            elseif entry.isExternal then
+                alpha = 0.8
             end
+            row.name:SetAlpha(alpha)
+            row.class:SetAlpha(alpha)
+            row.ep:SetAlpha(alpha)
+            row.gp:SetAlpha(alpha)
+            row.pr:SetAlpha(alpha)
         else
             row:Hide()
         end

--- a/test/test_external_ui.lua
+++ b/test/test_external_ui.lua
@@ -1,0 +1,332 @@
+-----------------------------------------------------------------------
+-- test_external_ui.lua — Unit tests for external player UI indicators
+-- Covers: Standings display, Leaderboard display, ExportFrame CSV
+-----------------------------------------------------------------------
+
+-- Load stubs first
+require("test.wow_stubs")
+require("test.ace_stubs")
+
+-- Create the addon (simulates NewAddon call in Core.lua)
+local SimpleEPGP = LibStub("AceAddon-3.0"):NewAddon("SimpleEPGP",
+    "AceConsole-3.0", "AceEvent-3.0", "AceComm-3.0", "AceSerializer-3.0")
+
+-- Set up default config (simulates AceDB defaults)
+SimpleEPGP.db = LibStub("AceDB-3.0"):New("SimpleEPGPDB", {
+    profile = {
+        base_gp = 100,
+        min_ep = 0,
+        decay_percent = 15,
+        quality_threshold = 4,
+        standard_ilvl = 120,
+        gp_base_multiplier = nil,
+        slot_multipliers = {},
+        os_multiplier = 0.5,
+        de_multiplier = 0.0,
+        ep_per_boss = 100,
+        auto_ep_boss = true,
+        standby_percent = 1.0,
+        bid_timer = 30,
+        auto_distribute = false,
+        auto_distribute_delay = 3,
+        show_gp_tooltip = true,
+        announce_channel = "GUILD",
+        announce_awards = true,
+        announce_ep = true,
+        external_players = {},
+    },
+}, true)
+
+-- Load the module files (order matches .toc)
+dofile("SimpleEPGP/EPGP.lua")
+dofile("SimpleEPGP/GPCalc.lua")
+dofile("SimpleEPGP/Log.lua")
+dofile("SimpleEPGP/Comms.lua")
+dofile("SimpleEPGP/LootMaster.lua")
+dofile("SimpleEPGP/UI/Standings.lua")
+dofile("SimpleEPGP/UI/Leaderboard.lua")
+dofile("SimpleEPGP/UI/ExportFrame.lua")
+
+-- Initialize addon
+_G._testInitAddon("SimpleEPGP")
+
+describe("External Player UI Indicators", function()
+    local EPGP, Standings, Leaderboard, ExportFrame
+
+    before_each(function()
+        -- Reset officer notes
+        _G._testGuildRoster[1].officerNote = "5000,1000"
+        _G._testGuildRoster[2].officerNote = "3000,500"
+        _G._testGuildRoster[3].officerNote = "2000,2000"
+        _G._testGuildRoster[4].officerNote = "1000,100"
+        _G._testGuildRoster[5].officerNote = ""
+
+        -- Clear external players
+        SimpleEPGP.db.profile.external_players = {}
+
+        EPGP = SimpleEPGP:GetModule("EPGP")
+        Standings = SimpleEPGP:GetModule("Standings")
+        Leaderboard = SimpleEPGP:GetModule("Leaderboard")
+        ExportFrame = SimpleEPGP:GetModule("ExportFrame")
+
+        -- Build standings
+        EPGP:GUILD_ROSTER_UPDATE()
+
+        -- Reset UI state
+        Standings:SetRaidFilter(false)
+        Leaderboard:SetGrouping("none")
+        Leaderboard:SetFilter("all")
+    end)
+
+    describe("Standings display", function()
+        before_each(function()
+            Standings:Show()
+        end)
+
+        after_each(function()
+            Standings:Hide()
+        end)
+
+        it("includes external players in display data", function()
+            EPGP:AddExternalPlayer("Pugman", "WARRIOR")
+            EPGP:GUILD_ROSTER_UPDATE()
+            Standings:Show()  -- refresh
+
+            local data = Standings:GetDisplayData()
+            local found = false
+            for _, entry in ipairs(data) do
+                if entry.name == "Pugman" then
+                    found = true
+                    break
+                end
+            end
+            assert.is_true(found, "Expected Pugman in standings display")
+        end)
+
+        it("external players have isExternal flag in display data", function()
+            EPGP:AddExternalPlayer("Pugman", "HUNTER")
+            EPGP:GUILD_ROSTER_UPDATE()
+            Standings:Show()
+
+            local data = Standings:GetDisplayData()
+            for _, entry in ipairs(data) do
+                if entry.name == "Pugman" then
+                    assert.is_true(entry.isExternal)
+                end
+            end
+        end)
+
+        it("guild members do NOT have isExternal flag in display data", function()
+            EPGP:AddExternalPlayer("Pugman", "WARRIOR")
+            EPGP:GUILD_ROSTER_UPDATE()
+            Standings:Show()
+
+            local data = Standings:GetDisplayData()
+            for _, entry in ipairs(data) do
+                if entry.name == "Player1" then
+                    assert.is_nil(entry.isExternal)
+                end
+            end
+        end)
+
+        it("shows external and guild players together sorted by PR", function()
+            EPGP:AddExternalPlayer("Pugman", "WARRIOR")
+            SimpleEPGP.db.profile.external_players["Pugman"].ep = 10000
+            EPGP:GUILD_ROSTER_UPDATE()
+            Standings:Show()
+
+            local data = Standings:GetDisplayData()
+            -- Pugman has highest PR (10000/100 = 100), should be first
+            assert.are.equal("Pugman", data[1].name)
+            assert.is_true(data[1].isExternal)
+
+            -- Verify overall PR ordering
+            for i = 2, #data do
+                assert.is_true(data[i - 1].pr >= data[i].pr,
+                    "Expected PR descending order at index " .. i)
+            end
+        end)
+
+        it("external players counted in total display rows", function()
+            EPGP:AddExternalPlayer("Pugman", "WARRIOR")
+            EPGP:AddExternalPlayer("Allyheals", "PRIEST")
+            EPGP:GUILD_ROSTER_UPDATE()
+            Standings:Show()
+
+            local data = Standings:GetDisplayData()
+            -- 5 guild members + 2 external = 7
+            assert.are.equal(7, #data)
+        end)
+    end)
+
+    describe("Leaderboard display", function()
+        before_each(function()
+            Leaderboard:Show()
+        end)
+
+        after_each(function()
+            Leaderboard:Hide()
+        end)
+
+        it("includes external players in display items", function()
+            EPGP:AddExternalPlayer("Pugman", "WARRIOR")
+            EPGP:GUILD_ROSTER_UPDATE()
+            Leaderboard:Show()
+
+            local items = Leaderboard:GetDisplayItems()
+            local found = false
+            for _, item in ipairs(items) do
+                if item.type == "row" and item.entry.name == "Pugman" then
+                    found = true
+                    break
+                end
+            end
+            assert.is_true(found, "Expected Pugman in leaderboard display")
+        end)
+
+        it("external players have isExternal flag in leaderboard items", function()
+            EPGP:AddExternalPlayer("Pugman", "HUNTER")
+            EPGP:GUILD_ROSTER_UPDATE()
+            Leaderboard:Show()
+
+            local items = Leaderboard:GetDisplayItems()
+            for _, item in ipairs(items) do
+                if item.type == "row" and item.entry.name == "Pugman" then
+                    assert.is_true(item.entry.isExternal)
+                end
+            end
+        end)
+
+        it("guild members do NOT have isExternal flag in leaderboard items", function()
+            EPGP:AddExternalPlayer("Pugman", "WARRIOR")
+            EPGP:GUILD_ROSTER_UPDATE()
+            Leaderboard:Show()
+
+            local items = Leaderboard:GetDisplayItems()
+            for _, item in ipairs(items) do
+                if item.type == "row" and item.entry.name == "Player1" then
+                    assert.is_nil(item.entry.isExternal)
+                end
+            end
+        end)
+
+        it("external players appear in class grouping", function()
+            EPGP:AddExternalPlayer("Pugman", "WARRIOR")
+            EPGP:GUILD_ROSTER_UPDATE()
+            Leaderboard:SetGrouping("class")
+            Leaderboard:Show()
+
+            local items = Leaderboard:GetDisplayItems()
+            -- Find the Warrior header — should include Pugman + Player1
+            local warriorHeader = nil
+            for _, item in ipairs(items) do
+                if item.type == "header" and item.key == "WARRIOR" then
+                    warriorHeader = item
+                end
+            end
+            assert.is_not_nil(warriorHeader)
+            assert.are.equal(2, warriorHeader.count)
+        end)
+
+        it("external players appear in role grouping", function()
+            EPGP:AddExternalPlayer("Pugman", "HUNTER")
+            EPGP:GUILD_ROSTER_UPDATE()
+            Leaderboard:SetGrouping("role")
+            Leaderboard:Show()
+
+            local items = Leaderboard:GetDisplayItems()
+            -- Hunter maps to DPS. Player3 is HUNTER, Player4 is MAGE = 2 DPS + Pugman = 3
+            local dpsHeader = nil
+            for _, item in ipairs(items) do
+                if item.type == "header" and item.key == "DPS" then
+                    dpsHeader = item
+                end
+            end
+            assert.is_not_nil(dpsHeader)
+            assert.are.equal(3, dpsHeader.count)
+        end)
+
+        it("external player count in display items is correct", function()
+            EPGP:AddExternalPlayer("Pugman", "WARRIOR")
+            EPGP:AddExternalPlayer("Allyheals", "PRIEST")
+            EPGP:GUILD_ROSTER_UPDATE()
+            Leaderboard:Show()
+
+            local items = Leaderboard:GetDisplayItems()
+            -- 5 guild + 2 external = 7 rows
+            assert.are.equal(7, #items)
+            for _, item in ipairs(items) do
+                assert.are.equal("row", item.type)
+            end
+        end)
+    end)
+
+    describe("ExportFrame CSV", function()
+        it("includes Source column header", function()
+            EPGP:GUILD_ROSTER_UPDATE()
+            local csv = ExportFrame:GetStandingsCSV()
+            local firstLine = csv:match("^([^\n]+)")
+            assert.are.equal("Name,Class,EP,GP,PR,Source", firstLine)
+        end)
+
+        it("guild members have 'guild' source", function()
+            EPGP:GUILD_ROSTER_UPDATE()
+            local csv = ExportFrame:GetStandingsCSV()
+            -- Player1 should appear with ,guild at the end
+            assert.is_truthy(csv:find("Player1,WARRIOR,%d+,%d+,[%d%.]+,guild"))
+        end)
+
+        it("external players have 'external' source", function()
+            EPGP:AddExternalPlayer("Pugman", "WARRIOR")
+            EPGP:GUILD_ROSTER_UPDATE()
+            local csv = ExportFrame:GetStandingsCSV()
+            assert.is_truthy(csv:find("Pugman,WARRIOR,%d+,%d+,[%d%.]+,external"))
+        end)
+
+        it("mixed guild and external players have correct sources", function()
+            EPGP:AddExternalPlayer("Pugman", "HUNTER")
+            EPGP:AddExternalPlayer("Allyheals", "PRIEST")
+            EPGP:GUILD_ROSTER_UPDATE()
+            local csv = ExportFrame:GetStandingsCSV()
+
+            -- Count guild and external sources
+            local guildCount = 0
+            local externalCount = 0
+            for line in csv:gmatch("[^\n]+") do
+                if line:match(",guild$") then
+                    guildCount = guildCount + 1
+                elseif line:match(",external$") then
+                    externalCount = externalCount + 1
+                end
+            end
+            assert.are.equal(5, guildCount, "Expected 5 guild entries")
+            assert.are.equal(2, externalCount, "Expected 2 external entries")
+        end)
+
+        it("CSV has correct number of columns per row", function()
+            EPGP:AddExternalPlayer("Pugman", "WARRIOR")
+            EPGP:GUILD_ROSTER_UPDATE()
+            local csv = ExportFrame:GetStandingsCSV()
+
+            for line in csv:gmatch("[^\n]+") do
+                -- Count commas: 5 commas = 6 columns
+                local _, commaCount = line:gsub(",", ",")
+                assert.are.equal(5, commaCount,
+                    "Expected 6 columns (5 commas) in: " .. line)
+            end
+        end)
+
+        it("CSV with no external players has all guild sources", function()
+            EPGP:GUILD_ROSTER_UPDATE()
+            local csv = ExportFrame:GetStandingsCSV()
+
+            local externalCount = 0
+            for line in csv:gmatch("[^\n]+") do
+                if line:match(",external$") then
+                    externalCount = externalCount + 1
+                end
+            end
+            assert.are.equal(0, externalCount, "Expected no external entries")
+        end)
+    end)
+end)


### PR DESCRIPTION
## Summary
- **Standings**: External players display with a `" *"` suffix after their name and reduced alpha (0.8) to visually distinguish them from guild members. The existing min-EP dimming (0.5 alpha) takes priority over the external indicator.
- **Leaderboard**: Same `" *"` suffix and 0.8 row alpha for external players. Works with all grouping modes (flat, by class, by role).
- **ExportFrame**: Added a `Source` column to the CSV export header and data rows, outputting `guild` or `external` for each player.
- **Tests**: New `test/test_external_ui.lua` with 15 tests covering external player display in Standings, Leaderboard (including class/role grouping), and CSV export (header, source values, column count).

## Files Changed
- `SimpleEPGP/UI/Standings.lua` — Name display and alpha logic in `UpdateRows()`
- `SimpleEPGP/UI/Leaderboard.lua` — Name display and row alpha in `Refresh()`
- `SimpleEPGP/UI/ExportFrame.lua` — CSV header/data rows + `GetStandingsCSV()` test accessor
- `test/test_external_ui.lua` — New test file

## Design Decisions
- Chose `" *"` suffix (as recommended in issue) over a separate column or color-only approach since it works universally with class-colored and uncolored names
- Alpha 0.8 is subtle enough to not interfere with readability while providing visual distinction
- Min-EP dimming (0.5) takes priority — an external player below min EP gets 0.5, not 0.8
- CSV uses lowercase `guild`/`external` to match the issue specification

## Test Plan
- [x] `luacheck` passes with 0 warnings / 0 errors
- [ ] `busted test/` passes all tests (sandbox blocked test execution — please verify)
- [ ] Visual verification in-game: external players show `" *"` suffix and slightly dimmed rows
- [ ] CSV export includes Source column with correct values

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)